### PR TITLE
Improved CLI workflow, with bash script and separate config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,56 @@ Auto-SelfControl helps you to create a weekly schedule for [SelfControl](http://
 You can plan for every weekday if and when SelfControl should start and stop.
 
 
-## Install
-- [SelfControl](http://selfcontrolapp.com) is required and should be installed in the application directory (however, custom paths are also supported).
-- Start SelfControl and backup your blacklist as it might get overridden by Auto-SelfControl.
-- [Download Auto-SelfControl](../../archive/master.zip) and copy/extract it to a directory on your Mac (e.g. `~/auto-selfcontrol`).
-- Edit the config.json (see [Configuration](#configuration) first).
-- Open Terminal.app and navigate to the directory. (e.g. `cd ~/auto-selfcontrol`).
-- Execute `/usr/bin/python setup.py install` to install the packages required to run Auto-SeltControl.
-- Execute `sudo /usr/bin/python auto-selfcontrol.py` to install Auto-SelfControl with the block-schedule defined in [config.json](config.json). __Important:__ If you change [config.json](config.json) later, you have to call the installation command again or Auto-SelfControl might not start at the right time!
+## Installation
+
+### With Homebrew (under construction)
+
+The easiest way to install Auto-SelfControl is with [Homebrew](https://brew.sh/). Install Auto-SelfControl by running the following command in the Terminal:
+
+    brew install auto-selfcontrol
+
+If you already have [SelfControl](http://selfcontrolapp.com), start it and **backup your blacklist** as it might get overridden by Auto-SelfControl. 
+
+If you do not have [SelfControl](http://selfcontrolapp.com) already installed on your system, you can install it with [Homebrew Cask](https://caskroom.github.io/):
+
+    brew cask install selfcontrol
+
+### Manual installation
+
+Download this repository to a directory on your system (e.g., `~/auto-selfcontrol/`).
+
+    chmod +x auto-selfcontrol
+
+Run from this specific repository
+
+    ./auto-selfcontrol <config|activate|help>
+
+Or create a symlink in your `/usr/local/bin` folder to access it from anywhere.
+
+## Usage
+
+Edit the time configuration (see [Configuration](#configuration)) first:
+
+    auto-selfcontrol config
+
+When your block-schedule in [config.json](config.json) is ready, activate it by running:
+
+    auto-selfcontrol activate
+
+__Important:__ If you change [config.json](config.json) later, you have to call the `auto-selfcontrol activate` command again or Auto-SelfControl will not take the modifications into account!
 
 
 ## Uninstall
-- Delete the installation directory of Auto-SelfControl
-- Execute the following command in the Terminal.app:
-```
-sudo rm /Library/LaunchDaemons/com.parrot-bytes.auto-selfcontrol.plist
-```
+
+To remove the application (if installed with Homebrew):
+
+    brew uninstall auto-selfcontrol
+
+Or, manually, by removing the directory where you installed the files.
+
+You also need to remove the automatic schedule by executing the following command in the Terminal:
+
+    sudo rm /Library/LaunchDaemons/com.parrot-bytes.auto-selfcontrol.plist
 
 ## Configuration
 The following listing shows an example config.json file that blocks every Monday from 9am to 5.30pm and on every Tuesday from 10am to 4pm:
@@ -52,7 +86,7 @@ The following listing shows an example config.json file that blocks every Monday
         ]
     }
 ```
-- _username_ should be the Mac OS X username.
+- _username_ should be the macOS username.
 - _selfcontrol-path_ is the absolute path to [SelfControl](http://selfcontrolapp.com).
 - _host-blacklist_ contains the list of sites that should get blacklisted as a string array. Please note that the blacklist in SelfControl might get overridden and should be __backed up__ before using Auto-SelfControl.
 - _block-schedules_ contains a list of schedules when SelfControl should be started.
@@ -100,8 +134,8 @@ The following listing shows another example that blocks twitter and reddit every
 
 ### ImportError: No module named Foundation
 
-If you've installed Python using HomeBrew, you'll need to run Auto-SelfControl with the original Python installation from OS X:
+If you've installed another version of Python (e.g., using Homebrew), you'll need to run Auto-SelfControl with the original Python installation from macOS:
 
     sudo /usr/bin/python auto-selfcontrol.py
-    
-There are also other options, including installing `pyobjc` on your brewed Python (`pip install pyobjc`). [See this thread for alternative solutions](https://stackoverflow.com/questions/1614648/importerror-no-module-named-foundation#1616361).
+
+There are also other options, including installing `pyobjc` on your own Python version (`pip install pyobjc`). [See this thread for alternative solutions](https://stackoverflow.com/questions/1614648/importerror-no-module-named-foundation#1616361).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can plan for every weekday if and when SelfControl should start and stop.
 The easiest way to install Auto-SelfControl is with [Homebrew](https://brew.sh/). Install Auto-SelfControl by running the following command in the Terminal:
 
     brew tap sbibauw/utils
-    brew install --HEAD auto-selfcontrol
+    brew install auto-selfcontrol
 
 If you already have [SelfControl](http://selfcontrolapp.com), start it and **backup your blacklist** as it might get overridden by Auto-SelfControl. 
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ You can plan for every weekday if and when SelfControl should start and stop.
 
 ## Installation
 
-### With Homebrew (under construction)
+### With Homebrew
 
 The easiest way to install Auto-SelfControl is with [Homebrew](https://brew.sh/). Install Auto-SelfControl by running the following command in the Terminal:
 
-    brew install auto-selfcontrol
+    brew tap sbibauw/utils
+    brew install --HEAD auto-selfcontrol
 
 If you already have [SelfControl](http://selfcontrolapp.com), start it and **backup your blacklist** as it might get overridden by Auto-SelfControl. 
 

--- a/auto-selfcontrol
+++ b/auto-selfcontrol
@@ -20,18 +20,30 @@ More instructions at https://github.com/andreasgrill/auto-selfcontrol"
 
 if [[ $1 ]]; then
     case "$1" in
+        # Edit configuration file
         config|edit|set|conf*)
+            # If no "config.json" in /usr/local/etc/auto-selfcontrol/
             if [[ ! -f $CONFIG_FILE ]]; then
-                curl -L -s "https://raw.githubusercontent.com/andreasgrill/auto-selfcontrol/master/config.json" -o $CONFIG_FILE
-                echo "Downloaded sample configuration in $CONFIG_FILE"
+                # If existing "config.json" in the cwd, copy it
+                if [[ -f config.json ]]; then
+                    cp "config.json" $CONFIG_FILE
+                    echo "Copied config.json from the current directory to $CONFIG_FILE"
+                # else download sample config from github repository
+                else
+                    curl -L -s "https://raw.githubusercontent.com/andreasgrill/auto-selfcontrol/master/config.json" -o $CONFIG_FILE
+                    echo "Downloaded sample configuration in $CONFIG_FILE"
+                fi
             fi
             echo "Opening $CONFIG_FILE"
+            # Opening with default editor set as $EDITOR
             if [[ $EDITOR ]]; then
                 $EDITOR $CONFIG_FILE
+            # Or with default GUI text editor (txt files > Open with...)
             else
                 open -t $CONFIG_FILE
             fi
             ;;
+        # Install plist config
         activate|install)
             sudo /usr/bin/python auto-selfcontrol.py
             exit 0

--- a/auto-selfcontrol
+++ b/auto-selfcontrol
@@ -45,7 +45,7 @@ if [[ $1 ]]; then
             ;;
         # Install plist config
         activate|install)
-            sudo /usr/bin/python auto-selfcontrol.py
+            sudo /usr/bin/python /usr/local/bin/auto-selfcontrol.py
             exit 0
             ;;
         -h|--help|help|*)

--- a/auto-selfcontrol
+++ b/auto-selfcontrol
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Auto-SelfControl basic command-line interface
+
+CONFIG_FILE="/usr/local/etc/auto-selfcontrol/config.json"
+b=$(tput bold)
+n=$(tput sgr0)
+HELP_TEXT="Auto-SelfControl (c) Andreas Grill
+Small utility to schedule start and stop times of SelfControl.
+
+Usage: ${b}$(basename "$0") <config|activate|help>${n}
+
+where:
+  ${b}config${n}    Open the schedule configuration file in a text
+              editor to set up weekly parameters
+  ${b}activate${n}  Activate the automatic start/stop of SelfControl
+              according to schedules defined in configuration
+  ${b}help${n}      Show this help message
+
+More instructions at https://github.com/andreasgrill/auto-selfcontrol"
+
+if [[ $1 ]]; then
+    case "$1" in
+        config|edit|set|conf*)
+            if [[ ! -f $CONFIG_FILE ]]; then
+                curl -L -s "https://raw.githubusercontent.com/andreasgrill/auto-selfcontrol/master/config.json" -o $CONFIG_FILE
+                echo "Downloaded sample configuration in $CONFIG_FILE"
+            fi
+            echo "Opening $CONFIG_FILE"
+            if [[ $EDITOR ]]; then
+                $EDITOR $CONFIG_FILE
+            else
+                open -t $CONFIG_FILE
+            fi
+            ;;
+        activate|install)
+            sudo /usr/bin/python auto-selfcontrol.py
+            exit 0
+            ;;
+        -h|--help|help|*)
+            echo "$HELP_TEXT"
+            exit 0
+            ;;
+    esac
+else
+    echo "$HELP_TEXT"
+    exit 0
+fi

--- a/auto-selfcontrol
+++ b/auto-selfcontrol
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Auto-SelfControl basic command-line interface
 
-CONFIG_FILE="~/.config/auto-selfcontrol/config.json"
+CONFIG_FILE="/usr/local/etc/auto-selfcontrol/config.json"
 b=$(tput bold)
 n=$(tput sgr0)
 HELP_TEXT="Auto-SelfControl (c) Andreas Grill

--- a/auto-selfcontrol
+++ b/auto-selfcontrol
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Auto-SelfControl basic command-line interface
 
-CONFIG_FILE="/usr/local/etc/auto-selfcontrol/config.json"
+CONFIG_FILE="~/.config/auto-selfcontrol/config.json"
 b=$(tput bold)
 n=$(tput sgr0)
 HELP_TEXT="Auto-SelfControl (c) Andreas Grill
@@ -22,7 +22,7 @@ if [[ $1 ]]; then
     case "$1" in
         # Edit configuration file
         config|edit|set|conf*)
-            # If no "config.json" in /usr/local/etc/auto-selfcontrol/
+            # If no "config.json" in ~/.config/auto-selfcontrol/
             if [[ ! -f $CONFIG_FILE ]]; then
                 # If existing "config.json" in the cwd, copy it
                 if [[ -f config.json ]]; then

--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/python
 
 import subprocess
 import os

--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -262,18 +262,19 @@ if __name__ == "__main__":
                          rights, such as:\nsudo python {file} \
                          ".format(file=os.path.realpath(__file__)))
 
-    parser = OptionParser()
-    parser.add_option("-r", "--run", action="store_true",
+    PARSER = OptionParser()
+    PARSER.add_option("-r", "--run", action="store_true",
                       dest="run", default=False)
-    (opts, args) = parser.parse_args()
+    (OPTS, ARGS) = PARSER.parse_args()
     CONFIG = load_config([CONFIG_FILE])
 
-    if opts.run:
+    if OPTS.run:
         run(CONFIG)
     else:
         check_config(CONFIG)
         install(CONFIG)
-        if not check_if_running(CONFIG["username"]) and any(s for s in CONFIG["block-schedules"] if is_schedule_active(s)):
+        if not check_if_running(CONFIG["username"]) and \
+           any(s for s in CONFIG["block-schedules"] if is_schedule_active(s)):
             print("> Active schedule found for SelfControl!")
             print("> Start SelfControl (this could take a few minutes)\n")
             run(CONFIG)

--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -249,8 +249,7 @@ def exit_with_error(message):
 
 
 if __name__ == "__main__":
-    CONFIG_DIR = os.path.join(os.path.expanduser('~'),
-                              '.config/auto-selfcontrol')
+    CONFIG_DIR = os.path.join('/usr/local/etc/auto-selfcontrol')
     CONFIG_FILE = os.path.join(CONFIG_DIR, 'config.json')
 
     sys.excepthook = excepthook

--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -248,8 +248,9 @@ def exit_with_error(message):
 
 
 if __name__ == "__main__":
-    config_dir = os.path.realpath('~/.config/auto-selfcontrol')
-    config_file = os.path.join(config_dir, 'config.json')
+    home_dir = os.path.expanduser('~')
+    config_dir = os.path.realpath('.config/auto-selfcontrol')
+    config_file = os.path.join(home_dir, config_dir, 'config.json')
 
     sys.excepthook = excepthook
 

--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -248,7 +248,9 @@ def exit_with_error(message):
 
 
 if __name__ == "__main__":
-    __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+    config_dir = os.path.realpath('/usr/local/etc/auto-selfcontrol')
+    config_file = os.path.join(config_dir, 'config.json')
+
     sys.excepthook = excepthook
 
     syslog.openlog("Auto-SelfControl")
@@ -261,7 +263,7 @@ if __name__ == "__main__":
     parser.add_option("-r", "--run", action="store_true",
                       dest="run", default=False)
     (opts, args) = parser.parse_args()
-    config = load_config([os.path.join(__location__, "config.json")])
+    config = load_config([config_file])
 
     if opts.run:
         run(config)

--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -248,7 +248,7 @@ def exit_with_error(message):
 
 
 if __name__ == "__main__":
-    config_dir = os.path.realpath('/usr/local/etc/auto-selfcontrol')
+    config_dir = os.path.realpath('~/.config/auto-selfcontrol')
     config_file = os.path.join(config_dir, 'config.json')
 
     sys.excepthook = excepthook


### PR DESCRIPTION
I propose to change the default usage of Auto-SelfControl by having a basic bash script (`[auto-selfcontrol](auto-selfcontrol)`) be the main entry point, and allowing both a easy access to edit `config.json` (`auto-selfcontrol config` or `auto-selfcontrol edit`) and a separate command to activate/install the defined block-schedule (`auto-selfcontrol activate` or `auto-selfcontrol install`).

Simultaneously, `config.json` has been moved to the default configuration dir on mac/unix: `/usr/local/etc/` (so `/usr/local/etc/auto-selfcontrol/config.json`). This allows to update the program without the config file being affected.

More importantly, all these modifications are proposed to allow a very easy and automated installation with Homebrew (a simple `brew install auto-selfcontrol`). I have already prepared the ruby Formula which does everything (install `auto-selfcontrol` to `/usr/local/bin/`, the configuration file to `/usr/local/etc/`, etc.).

Feel free to cherrypick only what you think is relevant of course.