### PR TITLE
Feature: Easier input of schedule

### DIFF
--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -109,7 +109,17 @@ def get_duration_minutes(endhour, endminute):
 
 def get_schedule_weekdays(schedule):
     """ returns a list of weekdays the specified schedule is active """
-    return [schedule["weekday"]] if schedule.get("weekday", None) is not None else range(1, 8)
+    if schedule.get("weekday", None) is not None:
+        if schedule["weekday"] == "weekdays":
+            return range(1,6)
+        elif schedule["weekday"] == "weekends":
+            return range(6,8)
+        elif type(schedule["weekday"]) == list:
+            return schedule["weekday"]
+        elif type(schedule["weekday"]) == int:
+            return [schedule["weekday"]]
+    else:
+        return range(1,8)
 
 
 def set_selfcontrol_setting(key, value, username):


### PR DESCRIPTION
Hi, I made a simple but useful change to the code.

Now, in `config.json` for scheduling, instead of just writing a number for the day, such as `1` or `3` for Monday and Wednesday respectively, you have more options:

- `"weekdays"` will use Monday to Friday
- `"weekends"` will use Saturday and Sunday
- Also have list option such as `[1,3,5]` for Monday, Wednesday and Friday or `[1,2,3,4,5,6]`, etc however you wish.

It still supports the earlier way of using the integer representation of the day, as well as letting the value be `None` (which will be all 7 days of the week).