### PR TITLE
Fix issue #52

### DIFF
--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -183,6 +183,7 @@ def check_if_running(api, config):
         defaults = get_selfcontrol_settings(username)
         return defaults.has_key("BlockStartedDate") and not NSDate.distantFuture().isEqualToDate_(defaults["BlockStartedDate"])
     elif api is Api.V3:
+        execSelfControl(config, ["--checkup"])
         output = execSelfControl(config, ["--is-running"])
         m = re.search(
             get_selfcontrol_out_pattern(r'(NO|YES)'), output, re.MULTILINE)


### PR DESCRIPTION
Adds a line to run the SelfControl helper with `--checkup`.
This should clear the block if it's finished, so that `check_if_running` returns the correct result.
Should solve issue #52 