### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you already have [SelfControl](http://selfcontrolapp.com), start it and **bac
 
 If you do not have [SelfControl](http://selfcontrolapp.com) already installed on your system, you can install it with [Homebrew Cask](https://caskroom.github.io/):
 
-    brew cask install selfcontrol
+    brew install --cask selfcontrol
 
 ### Manual installation
 


### PR DESCRIPTION
brew recently disabled the `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524