### PR TITLE
Move default config file to ~/.config/auto-selfcontrol

### DIFF
--- a/auto-selfcontrol
+++ b/auto-selfcontrol
@@ -3,12 +3,17 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# Check if auto-selfcontrol was installed through brew and set the config.json location accordingly
-if [[ $DIR == /usr/local/* ]]; then
-    mkdir -p /usr/local/etc/auto-selfcontrol || true
+# Check if config file already exists
+if [[ -d "$HOME/.config/auto-selfcontrol/" ]]; then
+    CONFIG_FILE="$HOME/.config/auto-selfcontrol/config.json"
+elif [ -f "/usr/local/etc/auto-selfcontrol/config.json" ]; then
     CONFIG_FILE="/usr/local/etc/auto-selfcontrol/config.json"
-else
+elif [ -f "$DIR/config.json" ]; then
     CONFIG_FILE="$DIR/config.json"
+else
+    # No config file found: create it in ~/.config/auto-selfcontrol/
+    mkdir -p "$HOME/.config/auto-selfcontrol/" || true
+    CONFIG_FILE="$HOME/.config/auto-selfcontrol/config.json"
 fi
 
 b=$(tput bold)

--- a/auto-selfcontrol.py
+++ b/auto-selfcontrol.py
@@ -14,7 +14,7 @@ from Foundation import NSUserDefaults, CFPreferencesSetAppValue, CFPreferencesAp
 from pwd import getpwnam
 from optparse import OptionParser
 
-SETTINGS_DIR = '/usr/local/etc/auto-selfcontrol'
+SETTINGS_DIR = os.path.expanduser("~") + '/.config/auto-selfcontrol'
 
 # Configure global logger
 LOGGER = logging.getLogger("Auto-SelfControl")
@@ -51,12 +51,17 @@ def find_config():
         path=os.path.dirname(os.path.realpath(__file__)))
     global_config_file = "{path}/config.json".format(
         path=SETTINGS_DIR)
+    prev_global_config_file = "{path}/config.json".format(
+        path='/usr/local/etc/auto-selfcontrol')
 
     if os.path.exists(local_config_file):
         return local_config_file
 
     if os.path.exists(global_config_file):
         return global_config_file
+
+    if os.path.exists(prev_global_config_file):
+        return prev_global_config_file
 
     exit_with_error(
         "There was no config file found, please create a config file.")


### PR DESCRIPTION
The config file will be looked for in
- `~/.config/auto-selfcontrol/config.json`
- `/usr/local/etc/auto-selfcontrol/config.json`
- `$DIR/config.json` (same directory as where Auto-SelfControl has been installed)
If not found, created in `~/.config/auto-selfcontrol/config.json`

This will make it easier to backup and sync it across installs. Answers #58

It also works on new ARM-based M1 Macs where brewed bins are in `/opt/homebrew/`, no longer in `/usr/local/`.

This will not move an existing config file.
Moving can be done manually:

    mv /usr/local/etc/auto-selfcontrol/config.json ~/.config/auto-selfcontrol/

`auto-selfcontrol` will find this new location first.